### PR TITLE
Revisit imports

### DIFF
--- a/ast/node.go
+++ b/ast/node.go
@@ -83,6 +83,14 @@ type WhereExpr struct {
 	Val  Expr
 }
 
+type ImportExpr struct {
+	Pos token.Span
+	// Typically "sha256".
+	HashAlgo string
+	// Any literal, typically a byte-string.
+	Value Literal
+}
+
 func (b Ident) expr()         {}
 func (b Literal) expr()       {}
 func (b BinaryExpr) expr()    {}
@@ -95,6 +103,7 @@ func (b RecordExpr) expr()    {}
 func (b AccessExpr) expr()    {}
 func (b ListExpr) expr()      {}
 func (b WhereExpr) expr()     {}
+func (b ImportExpr) expr()    {}
 
 func span(start, end Expr) token.Span {
 	return token.Span{
@@ -122,3 +131,4 @@ func (b RecordExpr) Span() token.Span { return b.Pos }
 func (b AccessExpr) Span() token.Span { return b.Pos }
 func (b ListExpr) Span() token.Span   { return b.Pos }
 func (b *WhereExpr) Span() token.Span { return span(b.Expr, b.Val) }
+func (b ImportExpr) Span() token.Span { return b.Pos }

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -162,11 +162,19 @@ func TestFailures(t *testing.T) {
 	}
 }
 
+func eval(e *Environment, source string) (Value, error) {
+	scrap, err := e.Read([]byte(source))
+	if err != nil {
+		return nil, err
+	}
+	return e.Eval(scrap)
+}
+
 // Evaluates an expression and compares the string representation of the
 // result with a target string; optionally with some additional variables
 // in scope.
 func evalString(t *testing.T, source, expected string) {
-	val, err := NewEnvironment(nil).Eval([]byte(source))
+	val, err := eval(NewEnvironment(), source)
 
 	if err != nil {
 		t.Error(err)
@@ -179,7 +187,7 @@ func evalString(t *testing.T, source, expected string) {
 
 // Evaluates to a comparable value
 func evalFailure(t *testing.T, source string, expected string) {
-	val, err := NewEnvironment(nil).Eval([]byte(source))
+	val, err := eval(NewEnvironment(), source)
 
 	if err == nil {
 		t.Errorf("%s - should fail but got %s", source, val)
@@ -191,12 +199,13 @@ func evalFailure(t *testing.T, source string, expected string) {
 }
 
 func TestEvalImport(t *testing.T) {
-	env := NewEnvironment(MapFetcher{
+	env := NewEnvironment()
+	env.UseFetcher(MapFetcher{
 		"a948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a447": `3 + $sha256~~a948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a445`,
 		"a948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a445": `2`,
 	})
 
-	val, err := env.Eval([]byte(`$sha256~~a948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a447 - 1`))
+	val, err := eval(env, `$sha256~~a948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a447 - 1`)
 	if err != nil {
 		t.Error(err)
 	} else {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -204,6 +204,9 @@ func (p *parser) parseUnaryExpr() ast.Expr {
 
 	case token.OPTION:
 		return p.parseEnum()
+
+	case token.IMPORT:
+		return p.parseImport()
 	}
 
 	p.unexpected()
@@ -470,5 +473,31 @@ func (p *parser) parseVariant() *ast.VariantExpr {
 	return &ast.VariantExpr{
 		Tag: id,
 		Typ: typ,
+	}
+}
+
+func (p *parser) parseImport() *ast.ImportExpr {
+	start := p.span.Start
+
+	// Eat $.
+	p.next()
+
+	// Hash algo.
+	p.expect(token.IDENT)
+	algo := p.source.GetString(p.span)
+	p.next()
+
+	p.expect(token.BYTES)
+	bytes := ast.Literal{
+		Pos:  p.span,
+		Kind: p.tok,
+	}
+	end := p.span.End
+	p.next()
+
+	return &ast.ImportExpr{
+		Pos:      token.Span{Start: start, End: end},
+		HashAlgo: algo,
+		Value:    bytes,
 	}
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -129,6 +129,23 @@ func TestParses(t *testing.T) {
 	}
 }
 
+func TestImports(t *testing.T) {
+	valid := []string{
+		`$sha256~~a948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a447`,
+	}
+
+	for _, src := range valid {
+		se, err := ParseExpr(src)
+		if err != nil {
+			writeParseError(t, src, err)
+		}
+
+		if _, ok := se.Expr.(*ast.ImportExpr); !ok {
+			t.Errorf("Expected an ImportExpr, got %T", se.Expr)
+		}
+	}
+}
+
 func TestParseError(t *testing.T) {
 	examples := []struct{ source, message string }{
 		{`{ a = b ..c }`, `Expected RBRACE got SPREAD`},

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -249,6 +249,8 @@ func (s *Scanner) Scan() (token.Token, token.Span) {
 		switch ch {
 		case eof:
 			return token.EOF, token.Span{Start: start, End: start}
+		case '$':
+			return s.char(token.IMPORT)
 		case '(':
 			return s.switch2(token.LPAREN, ')', token.HOLE)
 		case ')':
@@ -323,7 +325,7 @@ func isAlpha(ch rune) bool {
 }
 
 func isLetter(ch rune) bool {
-	return 'a' <= lower(ch) && lower(ch) <= 'z' || ch == '$' || ch == '_' || ch >= utf8.RuneSelf && unicode.IsLetter(ch)
+	return 'a' <= lower(ch) && lower(ch) <= 'z' || ch == '_' || ch >= utf8.RuneSelf && unicode.IsLetter(ch)
 }
 func isDigit(ch rune) bool {
 	return isDecimal(ch) || ch >= utf8.RuneSelf && unicode.IsDigit(ch)

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -32,7 +32,8 @@ var elements = []elt{
 	// Special tokens
 	{token.IDENT, "hello", literal},
 	{token.IDENT, "f", literal},
-	{token.IDENT, "$sha256", literal}, // Import
+	{token.IMPORT, "$", operator},    // Import
+	{token.IDENT, "sha256", literal}, // Hash algo
 	{token.IDENT, "bytes/to-utf8-text", literal},
 	{token.INT, "13", literal},
 	{token.INT, "-13", literal},

--- a/token/token.go
+++ b/token/token.go
@@ -20,6 +20,9 @@ const (
 	begin_operators
 	HOLE // ()
 
+	// Import
+	IMPORT
+
 	// Where clauses.
 
 	ASSIGN // =
@@ -90,6 +93,8 @@ var tokens = [...]string{
 	WHERE:  "WHERE",
 	COMMA:  "COMMA",
 
+	IMPORT: "IMPORT",
+
 	DEFINE: "DEFINE",
 	PICK:   "PICK",
 	OPTION: "OPTION",
@@ -129,6 +134,8 @@ var operators = [...]string{
 	ASSIGN: "=",
 	WHERE:  ";",
 	COMMA:  ",",
+
+	IMPORT: "$",
 
 	DEFINE: ":",
 	PICK:   "::",

--- a/yards/cache_test.go
+++ b/yards/cache_test.go
@@ -17,9 +17,12 @@ func TestCache(t *testing.T) {
 		t.Error("expected not to read key1")
 	}
 
-	f := NewCacheFetcher(root, ByDirectory(fstest.MapFS{
+	f, err := NewCacheFetcher(root, ByDirectory(fstest.MapFS{
 		"key1": {Data: []byte("first")},
 	}))
+	if err != nil {
+		t.Error("could not create cache directory")
+	}
 
 	bs, err := f.FetchSha256("key1")
 	if err != nil {


### PR DESCRIPTION
By special casing imports (instead of treating them like a regular function call) we get type inference to work even for imported values.